### PR TITLE
added $data param to display_field method for EE 2.7.0 compatibility

### DIFF
--- a/third_party/category_field/ft.category_field.php
+++ b/third_party/category_field/ft.category_field.php
@@ -37,7 +37,7 @@ class  Category_field_ft extends EE_Fieldtype {
 
 	// --------------------------------------------------------------------
 
-	function display_field()
+	function display_field($data)
 	{
 		$this->_field_includes();
 


### PR DESCRIPTION
EE 2.7.0 expects the $data parameter in order to be compatible with the parent class, otherwise you'll encounter the following error in the CP:

Fatal error: Declaration of Category_field_ft::display_field() must be compatible with that of EE_Fieldtype::display_field() in /Library/WebServer/Documents/shanghai/nyush/expressionengine/third_party/category_field/ft.category_field.php on line 229
